### PR TITLE
Correctly handle ctrl+c when running commands

### DIFF
--- a/src/east/workspace_commands/basic_commands.py
+++ b/src/east/workspace_commands/basic_commands.py
@@ -309,7 +309,7 @@ def debug(east, extra_help, args):
     if extra_help:
         east.run_west("debug --help")
     else:
-        east.run_west("debug " + clean_up_extra_args(args))
+        east.run_west("debug " + clean_up_extra_args(args), ignore_sigint=True)
 
 
 @click.command(
@@ -339,7 +339,7 @@ def attach(east, extra_help, args):
     if extra_help:
         east.run_west("attach --help")
     else:
-        east.run_west("attach " + clean_up_extra_args(args))
+        east.run_west("attach " + clean_up_extra_args(args), ignore_sigint=True)
 
 
 @click.command(


### PR DESCRIPTION
# Description

<!--- A summary of the changes that this PR introduces. -->
As the title says, triggering ctrl+c combination is now correctly handled by east debug command, which uses gdb.

This change makes me very happy :)

## Areas of interest

<!--- Which parts of the code should code reviwer check?  -->
Added code.

## Checklist

<!--- Check items that you fullfilled, strikeout the ones that do not apply and write why  -->
- [x] Source code documentation for all newly added or changed functions was added/updated.


## After-review steps

<!--- Select one -->
* Code author will merge the PR by himself/herself.
