### PR TITLE
Add Codechecker commands

### DIFF
--- a/src/east/__main__.py
+++ b/src/east/__main__.py
@@ -8,6 +8,7 @@ from .workspace_commands import (
     build,
     bypass,
     clean,
+    codechecker,
     debug,
     flash,
     release,
@@ -33,6 +34,7 @@ rich_click.rich_click.COMMAND_GROUPS = {
                 "bypass",
                 "release",
                 "twister",
+                "codechecker",
             ],
         },
         {
@@ -42,6 +44,9 @@ rich_click.rich_click.COMMAND_GROUPS = {
     ],
     "east update": [{"name": "Subcommands", "commands": ["west", "env", "toolchain"]}],
     "east util": [{"name": "Subcommands", "commands": ["connect", "rtt"]}],
+    "east codechecker": [
+        {"name": "Subcommands", "commands": ["check", "fixit", "example-config"]}
+    ],
 }
 
 
@@ -91,6 +96,7 @@ cli.add_command(release)
 cli.add_command(debug)
 cli.add_command(attach)
 cli.add_command(twister)
+cli.add_command(codechecker)
 
 
 def main():

--- a/src/east/east_context.py
+++ b/src/east/east_context.py
@@ -402,6 +402,7 @@ class EastContext:
         self,
         ignore_uninstalled_ncs: bool = False,
         ignore_unsupported_ncs: bool = True,
+        check_only_west_workspace: bool = False,
     ):
         """
         This function contains a list of checks that every workspace (not system)
@@ -418,25 +419,35 @@ class EastContext:
         west.
 
         Args:
-            ignore_uninstalled_ncs (bool):  When true, self.does not exit if detected
+            ignore_uninstalled_ncs (bool):  When true, do not exit if detected
                                             NCS version is not installed by the
                                             Toolchain Manager. Workspace commands such
                                             as build, flash, clean should set this to
                                             False. Update command should set this to
                                             True.
 
-            ignore_unsupported_ncs (bool):  When true, self.does not exit if detected
+            ignore_unsupported_ncs (bool):  When true, do not exit if detected
                                             NCS version is not supported by the
                                             Toolchain Manager. Workspace commands such
                                             as build, flash, clean should set this to
                                             True. Update command should set this to
                                             false.
+
+            check_only_west_workspace (bool): When true, only check if we are in the
+                                              west Workspace, do not check for the rest
+                                              of the things. This is useful for the
+                                              codechecker command, which should be run
+                                              inside the west workspace, but does not
+                                              need nrf toolchain manager.
         """
         # Workspace commands can only be run inside west workspace, so exit if that is
         # not the case.
         if not self.west_dir_path:
             self.print(not_in_west_workspace_msg, highlight=False)
             self.exit()
+
+        if check_only_west_workspace:
+            return
 
         # Exit if east.yml could not be loaded from the project dir; it is not an error
         # if it does not exist, we support that.

--- a/src/east/workspace_commands/__init__.py
+++ b/src/east/workspace_commands/__init__.py
@@ -1,3 +1,4 @@
 from .basic_commands import attach, build, bypass, clean, debug, flash, twister
+from .codechecker_commands import codechecker
 from .release_commands import release
 from .update_commands import update

--- a/src/east/workspace_commands/codechecker_commands.py
+++ b/src/east/workspace_commands/codechecker_commands.py
@@ -163,7 +163,44 @@ analyzer:
 parse:
   - --trim-path-prefix=/*/project
   - --print-steps
+
+store:
+  - --trim-path-prefix=/*/project
 """
+
+
+@click.option(
+    "--endpoint",
+    type=str,
+    default="Default",
+    help="Endpoint of the Codechecker server. Default: 'Default'",
+)
+@click.option(
+    "--url",
+    type=str,
+    default="http://localhost:8001",
+    help="URL of the Codechecker server. Default: 'http://localhost:8001'",
+)
+@click.command(**east_command_settings)
+@click.pass_obj
+def store(east, endpoint, url):
+    """Store the results of the [magenta bold]Codechecker[/] analysis to a server."""
+
+    # TODO: add better description, figure out how to generate the name
+
+    east.pre_workspace_command_check(check_only_west_workspace=True)
+
+    cc = east.consts["codechecker_path"]
+    cfg = os.path.join(east.project_dir, "codechecker_config.yaml")
+
+    name = "testtest"
+
+    store_cmd = (
+        f"{cc} store --name {name} --url {url}/{endpoint} "
+        f"--config {cfg} {CC_OUTPUT_DIR}"
+    )
+
+    east.run(store_cmd)
 
 
 @click.option(
@@ -209,4 +246,4 @@ def codechecker(east):
 codechecker.add_command(check)
 codechecker.add_command(example_config)
 codechecker.add_command(fixit)
-# codechecker.add_command(store)
+codechecker.add_command(store)

--- a/src/east/workspace_commands/codechecker_commands.py
+++ b/src/east/workspace_commands/codechecker_commands.py
@@ -1,0 +1,212 @@
+import os
+
+import click
+from rich.syntax import Syntax
+
+from ..east_context import east_command_settings, east_group_settings
+from .codechecker_helpers import (
+    check_for_build_folder,
+    check_for_codechecker_config_yaml,
+    check_for_compile_commands_json,
+    cleanup_plist_files,
+    create_skip_file,
+)
+
+CC_OUTPUT_DIR = os.path.join("build", "codechecker")
+
+
+@click.command(**east_command_settings)
+@click.pass_obj
+@click.option(
+    "-h",
+    "--html",
+    is_flag=True,
+    help="Instead of printing the results in the terminal, generate a html report. "
+    "Default: false.",
+)
+@click.option(
+    "-p",
+    "--dont-cleanup-plist",
+    is_flag=True,
+    help="Skips plist cleanup step. Default: false.",
+)
+@click.option(
+    "-s",
+    "--skip-file",
+    type=str,
+    help="Instead of generating a skip file, provide your own.",
+)
+@click.option(
+    "-a",
+    "--only-analyze",
+    is_flag=True,
+    help="Only perfrom analyze step and cleanup plist (if enabled). Default: false.",
+)
+def check(east, html, dont_cleanup_plist, skip_file, only_analyze):
+    """Run [magenta bold]Codechecker[/] analysis for a project in current working directory.
+
+    \b
+    \n\nExpects that a CodeChecker config file (codechecker_config.yaml) exists in the
+    project's root dir. That file is used to configure the analysis.
+    See https://github.com/Ericsson/codechecker/tree/master/docs/config_file.md for more
+    information. Run east codechecker example-config to see a suggested config file.
+
+    \n\nResults of analysis are printed in the terminal by default. If --html flag is given, a html report is generated instead.
+
+    \n\nBetween analysis and parsing of the results, the intermediary plist files are by default cleaned up to remove diagnostics that are not useful. To skip this step, use --dont-cleanup-plist flag.
+
+    \n\nCurrently removed diagnostics are:
+
+    \n\n- [bold magenta]Ineffective bitwise and operation[/], caused by Zephyr's [bold cyan]LOG_*[/] macros.
+    \n\n- [bold magenta]Conditional operator with identical true and false expressions[/], caused by Zephyr's [bold cyan]LOG_*[/], [bold cyan]SHELL_CMD_*[/], [bold cyan]APP_EVENT_MANAGER_*[/] macros.
+    \n\n- [bold magenta]Value stored to 'variable' is never read or used[/], but is actually later used in disabled [bold cyan]__ASSERT*[/] or [bold cyan]LOG_*[/] macros.
+
+    \n\nBy default, a generated skip file is used to skip needless analysis of the Zephyr, NCS and external repositories. If that is not desired, you can provide your own skip file with the --skip-file flag, check the link for more info: https://codechecker.readthedocs.io/en/latest/analyzer/user_guide/#skip
+
+
+    \n\n[bold]Note:[/] This command expects that the project's build folder contains compile_commands.json
+
+    \n\n[bold]Note:[/] This command can be only run from inside of a [bold yellow]West workspace[/].
+    """
+    east.pre_workspace_command_check(check_only_west_workspace=True)
+
+    cc = east.consts["codechecker_path"]
+    cfg = os.path.join(east.project_dir, "codechecker_config.yaml")
+    compile_commands = os.path.join("build", "compile_commands.json")
+
+    check_for_build_folder(east)
+    check_for_compile_commands_json(east, compile_commands)
+    check_for_codechecker_config_yaml(east, cfg)
+
+    if not skip_file:
+        skip_file = create_skip_file(east, CC_OUTPUT_DIR)
+
+    # Run analyze command
+    analyze_cmd = (
+        f"{cc} analyze --skip {skip_file} --output {CC_OUTPUT_DIR} "
+        f"{compile_commands} --config {cfg}"
+    )
+
+    east.run(analyze_cmd)
+
+    if not dont_cleanup_plist:
+        cleanup_plist_files(east, CC_OUTPUT_DIR)
+
+    if only_analyze:
+        return
+
+    # Run parse command
+    parse_cmd = f"{cc} parse --config {cfg} {CC_OUTPUT_DIR } {html} "
+
+    if html:
+        parse_cmd += f"--output {CC_OUTPUT_DIR } --export html "
+
+    result = east.run(parse_cmd, exit_on_error=False, return_output=True, silent=True)
+
+    # Print output of the parse command, with default rich highlighting, but without any
+    # other wrapping, cropping.
+    print_args = {
+        "highlight": True,
+        "overflow": "ignore",
+        "crop": False,
+        "soft_wrap": False,
+        "no_wrap": True,
+    }
+    east.print(result["output"], **print_args)
+
+
+@click.option(
+    "-a",
+    "--apply",
+    is_flag=True,
+    help="Apply the available automatic fixes. "
+    "This causes the modification of the source code. Default: false",
+)
+@click.command(**east_command_settings)
+@click.pass_obj
+def fixit(east, apply):
+    """Apply fixes suggested by the [magenta bold]Codechecker[/].
+
+    \b
+    \n\nSome analyzers may suggest some automatic bugfixes. Most of the times these are style issues which can be fixed easily. This command handles the listing and application of these automatic fixes.
+
+    \n\n[bold]Note:[/] This command should be ran after the [bold cyan]east codechecker check[/] command.
+
+    \n\n[bold]Note:[/] This command can be only run from inside of a [bold yellow]West workspace[/].
+    """
+
+    east.pre_workspace_command_check(check_only_west_workspace=True)
+
+    cc = east.consts["codechecker_path"]
+
+    fixit_cmd = f"{cc} fixit {CC_OUTPUT_DIR}"
+
+    if apply:
+        fixit_cmd += " --apply"
+
+    east.run(fixit_cmd)
+
+
+example_config_text = """
+analyzer:
+  - --keep-gcc-include-fixed
+  - --keep-gcc-intrin
+  # Uncomment below option when you want to use .clang-tidy file.
+  # - --analyzer-config=clang-tidy:take-config-from-directory=true
+  - --analyzers
+  - clang-tidy
+  - clangsa
+  - --enable=guideline:sei-cert
+  # Enable for cross translation unit analyis, but analysis will take longer.
+  # - --ctu
+
+parse:
+  - --trim-path-prefix=/*/project
+  - --print-steps
+"""
+
+
+@click.option(
+    "-c",
+    "--create",
+    is_flag=True,
+    help="Create example [bold magenta]codechecker_config.yaml[/] in the project's root dir.",
+)
+@click.command(**east_command_settings)
+@click.pass_obj
+def example_config(east, create):
+    """Show example [bold magenta]codechecker_config.yaml[/] file."""
+
+    east.pre_workspace_command_check(check_only_west_workspace=True)
+
+    if create:
+        with open(os.path.join(east.project_dir, "codechecker_config.yaml"), "w") as f:
+            f.write(example_config_text)
+
+        east.print(
+            "\nCreated [bold magenta]codechecker_config.yaml[/] file "
+            "in project's root dir."
+        )
+        return
+
+    east.print(
+        "\nExample [bold magenta]codechecker_config.yaml[/] file,"
+        " place this in your project's root dir:"
+    )
+    syntax = Syntax(
+        example_config_text, "yaml", theme="ansi_dark", background_color="default"
+    )
+    east.print(syntax)
+
+
+@click.group(**east_group_settings, subcommand_metavar="Subcommands")
+@click.pass_obj
+def codechecker(east):
+    """Command with several subcommands related to the [magenta bold]CodeChecker[/]."""
+    pass
+
+
+codechecker.add_command(check)
+codechecker.add_command(example_config)
+codechecker.add_command(fixit)
+# codechecker.add_command(store)

--- a/src/east/workspace_commands/codechecker_helpers.py
+++ b/src/east/workspace_commands/codechecker_helpers.py
@@ -1,0 +1,189 @@
+import glob
+import os
+import plistlib as plist
+import re
+
+
+def check_for_build_folder(east):
+    """Check that build dir exists."""
+
+    if not os.path.isdir("build"):
+        east.print(
+            "\nFolder [magenta bold italic]build[/] was [bold red]not found[/] in current working directory.\n\n"
+            "Build your project first and rerun this command."
+        )
+        east.exit()
+
+
+def check_for_compile_commands_json(east, compile_commands):
+    """Check that compile_commands.json exists in the build dir."""
+
+    if not os.path.exists(compile_commands):
+        east.print(
+            "\nFile [cyan bold]build/compile_commands.json[/] was [bold red]not found[/].\n"
+            "Check if your project's [cyan bold]CMakelists.txt[/] file contains the below line:\n\n"
+            "[bold]set(CMAKE_EXPORT_COMPILE_COMMANDS ON)[/]\n"
+        )
+        east.exit()
+
+
+def check_for_codechecker_config_yaml(east, cfg):
+    """Check that codechecker_config.yaml exists in the project's root dir."""
+
+    if not os.path.exists(cfg):
+        east.print(
+            "\nFile [cyan bold]codechecker_config.yaml[/] was [bold red]not found[/] in project's git root dir.\n"
+            "CodeChecker requires this file to function normally.\n\n"
+            "Run below command to see an example of a config: \n\n"
+            "\t[cyan bold]east codechecker example-config\n"
+        )
+        east.exit()
+
+
+def ineffective_log_macro_found(diag):
+    """Returns true if clang-tidy diagnostic is about ineffective bitwise and operation
+    in a LOG_* macro.
+
+    Production source code is full of those, and they are not really useful to see in
+    the reports. This function is used to filter them out.
+    """
+
+    desc = "ineffective bitwise and operation"
+
+    if diag["description"] == desc:
+        for path in diag["path"]:
+            if "message" in path:
+                hit = re.search("expanded from macro '.*LOG_.*'", path["message"])
+                if hit:
+                    return True
+    return False
+
+
+def conditional_operator_in_macro_found(diag):
+    """Returns true if clang-tidy diagnostic is about conditional operator in a
+    SHELL_CMD_* macro.
+    """
+
+    desc = "conditional operator with identical true and false expressions"
+
+    if diag["description"] == desc:
+        for path in diag["path"]:
+            if "message" in path:
+                patterns = [
+                    "expanded from macro 'SHELL_CMD_.*'",
+                    "expanded from macro 'APP_EVENT_TYPE_DEFINE'",
+                ]
+
+                for pattern in patterns:
+                    if re.search(pattern, path["message"]):
+                        return True
+    return False
+
+
+def var_never_read_before_disabled_macro_found(files, diag):
+    """Returns true if clang-tidy diagnostic is about value being stored to a variable,
+    and not being read, but this variable is later passed into some kind of a disabled
+    macro, such as __ASSERT* or LOG_* macro.
+    """
+
+    # Determine first if the description of the diagnostic is as expected for this case
+    desc_regexes = [
+        "Value stored to '(.*)' during its initialization is never read",
+        "Value stored to '(.*)' is never read",
+    ]
+
+    for desc_regex in desc_regexes:
+        hit = re.search(desc_regex, diag["description"])
+        if hit:
+            # Extracted variable name
+            var = hit.group(1)
+            break
+
+    if not hit:
+        return False
+
+    # A hit was found, locate the file where the diagnostic was found
+    file = files[diag["location"]["file"]]
+
+    # Open it and start reading from the line where the diagnostic was found
+    with open(file, "r") as f:
+        for _ in range(diag["location"]["line"]):
+            next(f)
+
+        for line in f:
+            # If you hit a line where variable is passed to __ASSERT* or LOG_* macro,
+            # then this is a false positive, and should be removed
+            patterns = [
+                f".*__ASSERT.*\(.*{var}.*,.*",
+                f".*LOG_.*\(.*,.*{var}.*",
+            ]
+
+            for pattern in patterns:
+                if re.search(pattern, line):
+                    return True
+
+            # If you hit a line that uses the variable in any way, then this is a true
+            # positive
+            if re.search(f".*{var}.*", line):
+                return False
+
+
+def cleanup_plist_files(east, output):
+    """Cleanup generated plist files by removing diagnostics that are not useful."""
+
+    # Conveniance variable, as the listeral is quite long
+    hash = "issue_hash_content_of_line_in_context"
+
+    for file in glob.glob(os.path.join(output, "*.plist")):
+
+        with open(file, "rb") as f:
+            data = plist.load(f)
+
+        diags = data["diagnostics"]
+
+        diags_for_removal = []
+
+        # Iterate through all diagnostics in the plist file and filter ones that you do
+        # not want.
+        # You can place any custom logic below to filter out diagnostics that you
+        # do not want.
+        for diag in diags:
+            if (
+                conditional_operator_in_macro_found(diag)
+                or ineffective_log_macro_found(diag)
+                or var_never_read_before_disabled_macro_found(data["files"], diag)
+            ):
+
+                diags_for_removal.append(diag[hash])
+
+        # Removal happens here
+        data["diagnostics"] = [
+            diag for diag in diags if diag[hash] not in diags_for_removal
+        ]
+
+        # Write the plist file back
+        with open(file, "wb") as f:
+            plist.dump(data, f)
+
+
+def create_skip_file(east, output):
+    """Create skip file for CodeChecker.
+
+    Generated skip file skips analysis of Zephyr, NCS, external repositories and
+    contents of any build folder inside the project's root dir.
+
+    We are skipping build folder because it contains generated .c files that are not in
+    other folders.
+    """
+
+    skip_file = os.path.join(output, "skip_file.txt")
+
+    os.makedirs(output, exist_ok=True)
+
+    if not os.path.exists(skip_file):
+        with open(skip_file, "w") as f:
+            f.write(f"-{east.project_dir}/*/build/*\n")
+            f.write(f"+{east.project_dir}/*\n")
+            f.write(f"-{east.west_dir_path}/*\n ")
+
+    return skip_file


### PR DESCRIPTION
# Description

<!--- A summary of the changes that this PR introduces. -->
This PR adds new command to the East: `east codechecker` and its subcommands.

Users can now thoroughly analyze their code with the greatest open-source tools that exist on the market.

Currently we are still missing a support for `store` command for storing the results to the server.
This is planned.

## Areas of interest

<!--- Which parts of the code should code reviwer check?  -->
Added code.

## Checklist

<!--- Check items that you fullfilled, strikeout the ones that do not apply and write why  -->
- [x] Source code documentation for all newly added or changed functions was added/updated.


## Related issues

<!--- Specify issues to which this PR is connected to. -->
Closes #86

## After-review steps

<!--- Select one -->
* Code author will merge the PR by himself/herself.
