### PR TITLE
Inject build type into CMake

### DIFF
--- a/src/east/workspace_commands/build_type_flag.py
+++ b/src/east/workspace_commands/build_type_flag.py
@@ -165,6 +165,10 @@ def construct_extra_cmake_arguments(east, build_type, board, build_dir, source_d
             east.print(build_type_misuse_no_east_yml_msg)
             east.exit()
 
+    # Set to empty string, it will stay like that unless we are inside app that uses
+    # build types
+    cmake_build_type = ""
+
     # Modify current working dir, if source_dir is used, rstrip is needed cause
     # path.join adds one "/" if joining empty string.
     source_dir = source_dir if source_dir else ""
@@ -241,6 +245,8 @@ def construct_extra_cmake_arguments(east, build_type, board, build_dir, source_d
                 # to plain west behaviour: no cmake args.
                 return ("", "")
         path_prefix = ""
+        build_types_str = build_type if build_type else "release"
+        cmake_build_type = f' -DEAST_BUILD_TYPE="{build_types_str}"'
 
     # "release" is a special, implicit, default, build type. Samples can request to
     # inherit from it, in that case only the common.conf is added to the build.
@@ -277,4 +283,4 @@ def construct_extra_cmake_arguments(east, build_type, board, build_dir, source_d
         else:
             # Previous cmake args are empty string, no build folder was found
             msg = "[italic bold dim]💬 Build folder not found, running CMake build[/]"
-        return required_cmake_args, msg
+        return required_cmake_args + cmake_build_type, msg

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -335,7 +335,7 @@ def helper_test_against_west_run(
 
         # This conversion is needed due to assert_has_calls interface
         calls = [
-            mocker.call(cmd, silent=True, return_output=True, exit_on_error=False)
+            mocker.call(cmd, exit_on_error=False, silent=True, return_output=True)
             for cmd in expected_west_cmds
         ]
         run_west.assert_has_calls(calls)

--- a/tests/test_build_type.py
+++ b/tests/test_build_type.py
@@ -62,17 +62,14 @@ def test_build_type_outside_project_dir(west_workplace, monkeypatch):
 @pytest.mark.parametrize(
     "build_type_flag, cmake_arg",
     [
-        ("", "-DCONF_FILE=conf/common.conf"),
+        ("", '-DCONF_FILE=conf/common.conf -DEAST_BUILD_TYPE="release"'),
         (
             "--build-type debug",
-            '-DCONF_FILE=conf/common.conf -DOVERLAY_CONFIG="conf/debug.conf"',
+            '-DCONF_FILE=conf/common.conf -DOVERLAY_CONFIG="conf/debug.conf" -DEAST_BUILD_TYPE="debug"',
         ),
         (
             "--build-type uart",
-            (
-                "-DCONF_FILE=conf/common.conf"
-                ' -DOVERLAY_CONFIG="conf/debug.conf;conf/uart.conf"'
-            ),
+            '-DCONF_FILE=conf/common.conf -DOVERLAY_CONFIG="conf/debug.conf;conf/uart.conf" -DEAST_BUILD_TYPE="uart"',
         ),
     ],
 )
@@ -98,11 +95,14 @@ def test_build_type_single_app_behaviour(
 @pytest.mark.parametrize(
     "multiapp, build_type_flag, cmake_arg",
     [
-        ("test_one", "", "-DCONF_FILE=conf/common.conf"),
+        ("test_one", "", '-DCONF_FILE=conf/common.conf -DEAST_BUILD_TYPE="release"'),
         (
             "test_one",
             "--build-type debug",
-            '-DCONF_FILE=conf/common.conf -DOVERLAY_CONFIG="conf/debug.conf"',
+            (
+                '-DCONF_FILE=conf/common.conf -DOVERLAY_CONFIG="conf/debug.conf"'
+                ' -DEAST_BUILD_TYPE="debug"'
+            ),
         ),
         (
             "test_one",
@@ -110,13 +110,17 @@ def test_build_type_single_app_behaviour(
             (
                 "-DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/debug.conf;conf/uart.conf"'
+                ' -DEAST_BUILD_TYPE="uart"'
             ),
         ),
-        ("test_two", "", "-DCONF_FILE=conf/common.conf"),
+        ("test_two", "", '-DCONF_FILE=conf/common.conf -DEAST_BUILD_TYPE="release"'),
         (
             "test_two",
             "--build-type rtt",
-            '-DCONF_FILE=conf/common.conf -DOVERLAY_CONFIG="conf/rtt.conf"',
+            (
+                '-DCONF_FILE=conf/common.conf -DOVERLAY_CONFIG="conf/rtt.conf"'
+                ' -DEAST_BUILD_TYPE="rtt"'
+            ),
         ),
         (
             "test_two",
@@ -124,6 +128,7 @@ def test_build_type_single_app_behaviour(
             (
                 "-DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/debug.conf;conf/rtt.conf"'
+                ' -DEAST_BUILD_TYPE="debug-rtt"'
             ),
         ),
     ],
@@ -235,7 +240,8 @@ def test_build_type_build_folder_behaviour_different_flags(
         f"build {build_type_flag}",
         expected_west_cmd=(
             "build -- -DCONF_FILE=conf/common.conf"
-            f' -DOVERLAY_CONFIG="{overlay_configs}"'
+            f' -DOVERLAY_CONFIG="{overlay_configs}" '
+            f'-DEAST_BUILD_TYPE="{build_type_flag.split(" ")[1]}"'
         ),
     )
 
@@ -645,6 +651,7 @@ def test_duplicated_names_in_east_yml(
             (
                 "build -b nrf52840dk_nrf52840 -- -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf"'
+                ' -DEAST_BUILD_TYPE="release"'
             ),
         ),
         (
@@ -653,6 +660,7 @@ def test_duplicated_names_in_east_yml(
                 "build -b nrf52840dk_nrf52840 -- -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf;'
                 'conf/debug.conf;conf/uart.conf"'
+                ' -DEAST_BUILD_TYPE="uart"'
             ),
         ),
         (
@@ -660,6 +668,7 @@ def test_duplicated_names_in_east_yml(
             (
                 "build -b nrf52840dk_nrf52840@1.0.0 -- -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf"'
+                ' -DEAST_BUILD_TYPE="release"'
             ),
         ),
         (
@@ -668,17 +677,20 @@ def test_duplicated_names_in_east_yml(
                 "build -b nrf52840dk_nrf52840@1.0.0 -- -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf;'
                 'conf/debug.conf;conf/uart.conf"'
+                ' -DEAST_BUILD_TYPE="uart"'
             ),
         ),
         (
             "build -b nonexisting_board",
-            "build -b nonexisting_board -- -DCONF_FILE=conf/common.conf",
+            "build -b nonexisting_board -- -DCONF_FILE=conf/common.conf"
+            ' -DEAST_BUILD_TYPE="release"',
         ),
         (
             "build -b nonexisting_board --build-type debug",
             (
                 "build -b nonexisting_board -- -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/debug.conf"'
+                ' -DEAST_BUILD_TYPE="debug"'
             ),
         ),
     ],
@@ -723,7 +735,8 @@ def test_different_build_dir_path_empty_dir(
         mocker,
         project_path,
         f"build -d {build_dir}",
-        f"build -d {build_dir} -- -DCONF_FILE=conf/common.conf",
+        f"build -d {build_dir} -- -DCONF_FILE=conf/common.conf "
+        '-DEAST_BUILD_TYPE="release"',
         should_succed=True,
     )
 
@@ -732,8 +745,8 @@ def test_different_build_dir_path_full_dir_same_build_type(
     west_workplace_parametrized, monkeypatch, mocker
 ):
     """With different build dir path and build folder that has same previous build type
-    files as current ones the west command should just include -d option and nothing
-    else.
+    files as current ones the west command should just include -d option,
+    EAST_BUILD_TYPE and nothing else.
     """
 
     project_path = west_workplace_parametrized["app"]
@@ -754,8 +767,8 @@ def test_different_build_dir_path_full_dir_same_build_type(
         mocker,
         project_path,
         f"build -d {build_dir} --build-type uart",
-        f"build -d {build_dir} -- -DCONF_FILE=conf/common.conf"
-        f' -DOVERLAY_CONFIG="{overlay_configs}"',
+        f"build -d {build_dir} -- -DCONF_FILE=conf/common.conf "
+        f'-DOVERLAY_CONFIG="{overlay_configs}" -DEAST_BUILD_TYPE="uart"',
         should_succed=True,
     )
 
@@ -789,7 +802,7 @@ def test_different_build_dir_path_full_dir_different_build_type(
         project_path,
         f"build -d {build_dir} --build-type debug",
         f"build -d {build_dir} -- -DCONF_FILE=conf/common.conf"
-        f' -DOVERLAY_CONFIG="{new_overlay_configs}"',
+        f' -DOVERLAY_CONFIG="{new_overlay_configs}" -DEAST_BUILD_TYPE="debug"',
         should_succed=True,
     )
 
@@ -799,17 +812,24 @@ def test_different_build_dir_path_full_dir_different_build_type(
     [
         (
             "build app/test_one",
-            "build app/test_one -- -DCONF_FILE=conf/common.conf",
+            (
+                "build app/test_one -- -DCONF_FILE=conf/common.conf "
+                '-DEAST_BUILD_TYPE="release"'
+            ),
         ),
         (
             "build app/test_two",
-            "build app/test_two -- -DCONF_FILE=conf/common.conf",
+            (
+                "build app/test_two -- -DCONF_FILE=conf/common.conf "
+                '-DEAST_BUILD_TYPE="release"'
+            ),
         ),
         (
             "build app/test_one --build-type debug",
             (
                 "build app/test_one -- -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/debug.conf"'
+                ' -DEAST_BUILD_TYPE="debug"'
             ),
         ),
         (
@@ -817,6 +837,7 @@ def test_different_build_dir_path_full_dir_different_build_type(
             (
                 "build app/test_two -- -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/debug.conf"'
+                ' -DEAST_BUILD_TYPE="debug"'
             ),
         ),
         (
@@ -825,6 +846,7 @@ def test_different_build_dir_path_full_dir_different_build_type(
                 "build -b nrf52840dk_nrf52840 app/test_one --"
                 " -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf"'
+                ' -DEAST_BUILD_TYPE="release"'
             ),
         ),
         (
@@ -834,6 +856,7 @@ def test_different_build_dir_path_full_dir_different_build_type(
                 " -DCONF_FILE=conf/common.conf"
                 ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf;'
                 'conf/debug.conf;conf/uart.conf"'
+                ' -DEAST_BUILD_TYPE="uart"'
             ),
         ),
     ],

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -90,41 +90,59 @@ expected_app_release_west_commands = [
     (
         "build -b custom_nrf52840dk@1.0.0 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/debug.conf"'
+        ' -DEAST_BUILD_TYPE="debug"'
     ),
     (
         "build -b custom_nrf52840dk@1.0.0 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/debug.conf;conf/uart.conf"'
+        ' -DEAST_BUILD_TYPE="uart"'
     ),
-    "build -b custom_nrf52840dk@1.0.0 app -- -DCONF_FILE=conf/common.conf",
+    (
+        "build -b custom_nrf52840dk@1.0.0 app -- -DCONF_FILE=conf/common.conf"
+        ' -DEAST_BUILD_TYPE="release"'
+    ),
     (
         "build -b custom_nrf52840dk@1.1.0 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/debug.conf"'
+        ' -DEAST_BUILD_TYPE="debug"'
     ),
     (
         "build -b custom_nrf52840dk@1.1.0 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/debug.conf;conf/uart.conf"'
+        ' -DEAST_BUILD_TYPE="uart"'
     ),
-    "build -b custom_nrf52840dk@1.1.0 app -- -DCONF_FILE=conf/common.conf",
+    (
+        "build -b custom_nrf52840dk@1.1.0 app -- -DCONF_FILE=conf/common.conf"
+        ' -DEAST_BUILD_TYPE="release"'
+    ),
     (
         "build -b custom_nrf52840dk@2.20.1 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/debug.conf"'
+        ' -DEAST_BUILD_TYPE="debug"'
     ),
     (
         "build -b custom_nrf52840dk@2.20.1 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/debug.conf;conf/uart.conf"'
+        ' -DEAST_BUILD_TYPE="uart"'
     ),
-    "build -b custom_nrf52840dk@2.20.1 app -- -DCONF_FILE=conf/common.conf",
+    (
+        "build -b custom_nrf52840dk@2.20.1 app -- -DCONF_FILE=conf/common.conf"
+        ' -DEAST_BUILD_TYPE="release"'
+    ),
     (
         "build -b nrf52840dk_nrf52840 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf;conf/debug.conf"'
+        ' -DEAST_BUILD_TYPE="debug"'
     ),
     (
         "build -b nrf52840dk_nrf52840 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf;conf/debug.conf;conf/uart.conf"'
+        ' -DEAST_BUILD_TYPE="uart"'
     ),
     (
         "build -b nrf52840dk_nrf52840 app -- -DCONF_FILE=conf/common.conf"
         ' -DOVERLAY_CONFIG="conf/nrf52840dk_nrf52840.conf"'
+        ' -DEAST_BUILD_TYPE="release"'
     ),
 ]
 


### PR DESCRIPTION
# Description

<!--- A summary of the changes that this PR introduces. -->
This PR will add a long waited functionality: whenever a east build is used in context of a build type, a `EAST_BUILD_TYPE` CMake define will be emitted.

`EAST_BUILD_TYPE` will contains string representation of a build type, most likely `release`, `debug`, `dev` or something else.

## Areas of interest

<!--- Which parts of the code should code reviwer check?  -->
Please check first commit. I refactored the `east build` command, however I think that there is way to many things happening in this and I need some way to manage the complexity.
Would creating a class that holds all build arguments help in any way?


## Checklist

<!--- Check items that you fullfilled, strikeout the ones that do not apply and write why  -->
- [x] Source code documentation for all newly added or changed functions was added/updated.


## After-review steps

<!--- Select one -->
* Code author will merge the PR by himself/herself.
