### PR TITLE
fix: Parsing of west.yml when determening NCS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+-   Parsing of `west.yml` when a project within the yaml does not contain the `repo-path` key.
+
 ## [0.23.0] - 2024-09-24
 
 ### Added

--- a/src/east/helper_functions.py
+++ b/src/east/helper_functions.py
@@ -171,18 +171,23 @@ def get_ncs_and_project_dir(west_dir_path: str) -> Tuple[str, str]:
     with open(west_yaml, "r") as file:
         manifest = yaml.safe_load(file)["manifest"]
 
-    try:
         ncs = list(
             filter(
-                lambda project: project["repo-path"] == "sdk-nrf", manifest["projects"]
+                lambda project: project.get("repo-path", "") == "sdk-nrf",
+                manifest["projects"],
             )
         )
-    except KeyError:
-        # This can happen in the case where there is no sdk-nrf repo in the west yaml
-        # file, project is probably using ordinary Zephyr.
+
+    # This can happen in the case where there is no sdk-nrf repo in the west yaml
+    # file, project is probably using ordinary Zephyr.
+    if len(ncs) == 0:
         return None, project_path
 
-    return (ncs[0]["revision"], project_path)
+    # Attempt to extract the NCS revision, which is optional.
+    # (We can safely access the first element, since we checked the length above)
+    revision = ncs[0].get("revision", None)
+
+    return (revision, project_path)
 
 
 def return_dict_on_match(array_of_dicts, key, value):


### PR DESCRIPTION
## Description

Turns our a "project" within west.yml does not need to contain the `repo-path` key.
I fix this by using .get instead of [].

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed
      functions.
- [x] ~~I updated all customer-facing technical documentation.~~ - This PR introduced only internal facing changes.

## After-review steps

<!--- Delete section or select one option -->

- Reviewer can merge and delete the branch.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
