### PR TITLE
feat: add ParsedTag classes and tests

### DIFF
--- a/src/east/modules/parsedtag.py
+++ b/src/east/modules/parsedtag.py
@@ -1,0 +1,103 @@
+from typing import NamedTuple, Optional
+
+
+class ParsedTag(NamedTuple):
+    """Container/interface class that holds the parsed tag information.
+
+    The instance of this class can be created either:
+    - from git describe output
+    - or from a tag given on the commandline.
+
+    The git describe command should be run with the following arguments:
+
+        git describe --tags --always --long --dirty=+
+
+    All possible outputs of the above command are handled:
+
+    - No commits in the repo: fatal: bad revision 'HEAD'
+    - No tags: 5a85363
+    - No tags and repo is dirty: 5a85363+
+    - HEAD is directly on a tag: v1.2.3-0-g98bddf3
+    - HEAD is directly on a tag and repo is dirty: v1.2.3-0-g98bddf3+
+    - HEAD is not directly on a tag: v1.2.3-1-g263ab82
+    - HEAD is not directly on a tag and repo is dirty: v1.2.3-1-g263ab82+
+
+    The ParsedTag object is intended to be passed to a class that does more specializes
+    tag parsing, like ZephyrSemver.
+    """
+
+    tag: Optional[str]
+    hash: Optional[str]
+    num_commits_from_tag: Optional[int]
+    dirty: bool
+    on_tag: bool
+
+    @classmethod
+    def from_git_describe(cls, input: str) -> "ParsedTag":
+        """Parse the output of git describe into a ParsedTag object.
+
+        Args:
+            input (str):            The output of git describe.
+        """
+        if (
+            input
+            == "fatal: not a git repository (or any of the parent directories): .git"
+        ):
+            # This happens when the current directory is not a git repository.
+            # It is not expected that we will ever get here due to other East checks,
+            # but let's handle it just in case.
+            raise ValueError(
+                "Not inside repository. Please run east inside a git repository."
+            )
+
+        if input == "fatal: bad revision 'HEAD'":
+            # This happens when there is no commit in the repo.
+            # Same thing as above.
+            raise ValueError(
+                "Not a single commit in the repository. Please make a commit before "
+                "running east."
+            )
+
+        parts = input.split("-")
+
+        if len(parts) == 1:
+            # This happens when there are no tags in the repo.
+            # The input is just the hash of the commit.
+            # We can generate a default version.
+            hash = parts[0]
+
+            if "+" in hash:
+                hash = hash[:-1]
+                dirty = True
+            else:
+                dirty = False
+
+            return cls(None, hash, 0, dirty, False)
+
+        elif len(parts) >= 3:
+            tag = "-".join(parts[:-2])
+            num_commits_from_tag = int(parts[-2])
+            hash = parts[-1]
+            # Drop 'g' in hash
+            hash = hash[1:]
+
+            if "+" in hash:
+                hash = hash[:-1]
+                dirty = True
+            else:
+                dirty = False
+
+            on_tag = num_commits_from_tag == 0
+
+            return cls(tag, hash, num_commits_from_tag, dirty, on_tag)
+        else:
+            raise ValueError(f"Invalid git describe format: {input}")
+
+    @classmethod
+    def from_cmd(cls, tag: str) -> "ParsedTag":
+        """Parse the tag from the command line into a ParsedTag object.
+
+        Args:
+            tag (str): The tag to parse.
+        """
+        return cls(tag, None, None, False, True)

--- a/src/east/modules/zephyr_semver.py
+++ b/src/east/modules/zephyr_semver.py
@@ -1,0 +1,173 @@
+from .parsedtag import ParsedTag
+
+
+def _parse_tag(tag: str) -> tuple[int, int, int, str, int]:
+    """Parse a tag.
+
+    This function contains logic to parse the semver-like tag into structured data.
+
+    The tweak part is only relevant for the cases where the tag is given on the
+    command line.
+    """
+    if not tag.startswith("v"):
+        raise ValueError(f"Invalid tag format: {tag}. Tag must start with 'v'.")
+
+    # Drop 'v' in a tag
+    tag_part = tag[1:]
+
+    if "+" in tag_part:
+        # We have a tweak
+        split = tag_part.split("+")
+        tweak = _parse_int_version(split[-1], tag, "Tweak")
+        # Join back the rest
+        tag_part = "+".join(split[:-1])
+    else:
+        # No tweak
+        tweak = 0
+
+    if "-" in tag_part:
+        # We have an extra part
+        split = tag_part.split("-")
+        tag_part = split[0]
+        # Join back the rest
+        extra = "-".join(split[1:])
+    else:
+        # No extra
+        extra = ""
+
+    # Split at "." and "-". Check how many parts we have.
+    parts = tag_part.split(".")
+
+    if len(parts) != 3:
+        raise ValueError(
+            f"Invalid tag format: {tag}. Expected format is vMAJOR.MINOR.PATCH[-extra]."
+        )
+
+    # Major, minor and patch are required
+    major = _parse_int_version(parts[0], tag, "Major")
+    minor = _parse_int_version(parts[1], tag, "Minor")
+    patch = _parse_int_version(parts[2], tag, "Patch")
+
+    return major, minor, patch, extra, tweak
+
+
+def _parse_int_version(part: str, tag: str, annotation: str) -> int:
+    """Try to parse an integer version part, such as major, minor, or patch.
+
+    Returns:
+        int: The parsed integer version part.
+    """
+    try:
+        return int(part)
+    except Exception:
+        raise ValueError(
+            f"Invalid tag format: {tag}. {annotation} version must be an integer."
+        )
+
+
+class ZephyrSemver:
+    """Zephyr Semver tag parser class.
+
+    This class has some expectations about the tag field that is contained by given
+    ParsedTag object.
+
+    - The pt.tag should be in format:
+
+        vMAJOR.MINOR.PATCH[-EXTRA][+TWEAK].
+
+    MAJOR, MINOR and PATCH are required, EXTRA and TWEAK are optional.
+    Only EXTRA can be an alphanumeric string, the rest must be integers.
+
+
+    Specific to the TWEAK number:
+
+    - If pt.num_commits_from_tag is set, then TWEAK is set to it.
+    - Otherwise it is set as determined by the pt.tag (if not given it is set to 0).
+
+
+    The Zephyr Semver object can then be represented:
+
+    - as a string, using the to_string() method. The output format is:
+
+        vMAJOR.MINOR.PATCH[-EXTRA][-HASH[+]][+TWEAK]
+
+    - or as a Zephyr VERSION file.
+
+
+    Specific to the to_string() representation:
+
+    - If the self.tweak is equeal to 0, it will not appear in the string representation.
+    - The plus '+' after the HASH part will only appear if the repo was dirty.
+    - to_string() representation will only contain HASH part if HASH was given and
+      pt.on_tag is False.
+
+    Specific to the to_version_file() representation:
+    - VERSION_TWEAK will be set to 255, if HEAD was on tag, but repo was dirty.
+    """
+
+    def __init__(self, pt: ParsedTag):
+        self.hash = pt.hash
+        self.dirty = pt.dirty
+        self.on_tag = pt.on_tag
+
+        if not pt.tag:
+            self.major = 0
+            self.minor = 0
+            self.patch = 0
+            self.extra = ""
+            self.tweak = 0
+            return
+
+        self.major, self.minor, self.patch, self.extra, self.tweak = _parse_tag(pt.tag)
+
+        # Override the tweak number if we have num_commits_from_tag, otherwise
+        # use value from the _parse_tag
+        if pt.num_commits_from_tag:
+            self.tweak = pt.num_commits_from_tag
+
+        if self.on_tag and self.dirty:
+            # We are directly on a dirty tag
+            self.tweak = 255
+
+    def to_string(self) -> str:
+        """Convert the object to a string representation.
+
+        Returns:
+            str: The string representation of the ParsedTag object.
+        """
+        ver = f"v{self.major}.{self.minor}.{self.patch}"
+
+        if self.extra:
+            ver += f"-{self.extra}"
+
+        if not self.hash:
+            # If there is no hash it means that from_cmd() was used.
+            if self.tweak:
+                ver += f"+{self.tweak}"
+            return ver
+
+        # We have a hash
+        if self.dirty:
+            ver += f"-{self.hash}+"
+        elif not self.on_tag and not self.dirty:
+            ver += f"-{self.hash}"
+
+        return ver
+
+    def to_version_file(self) -> str:
+        """Convert the object to a VERSION file representation.
+
+        Returns:
+            str: The VERSION file representation of the ParsedTag object.
+        """
+        f = [
+            f"VERSION_MAJOR = {self.major}",
+            f"VERSION_MINOR = {self.minor}",
+            f"PATCHLEVEL = {self.patch}",
+            f"VERSION_TWEAK = {self.tweak}",
+        ]
+
+        if self.extra:
+            f.append(f"EXTRAVERSION = {self.extra}")
+
+        return "\n".join(f)

--- a/tests/test_parsedtag.py
+++ b/tests/test_parsedtag.py
@@ -1,0 +1,207 @@
+import pytest
+
+from east.modules.parsedtag import ParsedTag
+from east.modules.zephyr_semver import ZephyrSemver
+
+
+def test_creating_parsedtag_when_not_in_git_repo():
+    """Test creating Parsed tag when not in git repo."""
+    with pytest.raises(ValueError):
+        ParsedTag.from_git_describe(
+            "fatal: not a git repository (or any of the parent directories): .git"
+        )
+
+
+def test_creating_parsedtag_without_any_commit():
+    """Test creating Parsed tag when there isn't any commit in repo."""
+    with pytest.raises(ValueError):
+        ParsedTag.from_git_describe("fatal: bad revision 'HEAD'")
+
+
+version_file_no_tag = """
+VERSION_MAJOR = 0
+VERSION_MINOR = 0
+PATCHLEVEL = 0
+VERSION_TWEAK = 0
+"""
+
+
+def test_creating_zephyrsemver_no_tag():
+    """Test creating ZephyrSemver when aren't any tags in the git repo."""
+    zs = ZephyrSemver(ParsedTag.from_git_describe("5a85363"))
+
+    assert zs.to_string() == "v0.0.0-5a85363"
+    assert zs.to_version_file() == version_file_no_tag.strip()
+
+
+def test_creating_zephyrsemver_no_tag_and_dirty():
+    """Test creating ZephyrSemver when aren't any tags in the git repo and state is dirty."""
+    zs = ZephyrSemver(ParsedTag.from_git_describe("5a85363+"))
+
+    assert zs.to_string() == "v0.0.0-5a85363+"
+    assert zs.to_version_file() == version_file_no_tag.strip()
+
+
+version_file_on_tag = """
+VERSION_MAJOR = 1
+VERSION_MINOR = 2
+PATCHLEVEL = 3
+VERSION_TWEAK = 0
+"""
+
+
+def test_creating_zephyrsemver_on_tag():
+    """Test creating ZephyrSemver when you are directly on a clean tag."""
+    zs = ZephyrSemver(ParsedTag.from_git_describe("v1.2.3-0-g98bddf3"))
+
+    assert zs.to_string() == "v1.2.3"
+    assert zs.to_version_file() == version_file_on_tag.strip()
+
+
+version_file_on_dirty_tag = """
+VERSION_MAJOR = 1
+VERSION_MINOR = 2
+PATCHLEVEL = 3
+VERSION_TWEAK = 255
+"""
+
+
+def test_creating_zephyrsemver_on_dirty_tag():
+    """Test creating ZephyrSemver when you are directly on dirty tag."""
+    zs = ZephyrSemver(ParsedTag.from_git_describe("v1.2.3-0-g98bddf3+"))
+
+    assert zs.to_string() == "v1.2.3-98bddf3+"
+    assert zs.to_version_file() == version_file_on_dirty_tag.strip()
+
+
+version_file_not_on_tag_clean_or_dirty = """
+VERSION_MAJOR = 1
+VERSION_MINOR = 2
+PATCHLEVEL = 3
+VERSION_TWEAK = 4
+"""
+
+
+def test_creating_zephyrsemver_not_on_tag():
+    """Test creating ZephyrSemver when you are not directly on a tag.
+
+    GIVEN when in git repo and not directly on a tag
+    WHEN creating ParsedTag
+    THEN Expected output should be returned
+    """
+    zs = ZephyrSemver(ParsedTag.from_git_describe("v1.2.3-4-g98bddf3"))
+
+    assert zs.to_string() == "v1.2.3-98bddf3"
+    assert zs.to_version_file() == version_file_not_on_tag_clean_or_dirty.strip()
+
+
+def test_creating_zephyrsemver_not_on_tag_dirty():
+    """Test creating ZephyrSemver when you are not directly on a tag and is dirty."""
+    zs = ZephyrSemver(ParsedTag.from_git_describe("v1.2.3-4-g98bddf3+"))
+
+    assert zs.to_string() == "v1.2.3-98bddf3+"
+    assert zs.to_version_file() == version_file_not_on_tag_clean_or_dirty.strip()
+
+
+version_file_with_extra_version = """
+VERSION_MAJOR = 1
+VERSION_MINOR = 2
+PATCHLEVEL = 3
+VERSION_TWEAK = 0
+EXTRAVERSION = rc1
+"""
+
+
+def test_creating_zephyrsemver_with_extra_field():
+    """Test creating ZephyrSemver when tag contains extra field."""
+    zs = ZephyrSemver(ParsedTag.from_git_describe("v1.2.3-rc1-0-g98bddf3"))
+
+    assert zs.to_string() == "v1.2.3-rc1"
+    assert zs.to_version_file() == version_file_with_extra_version.strip()
+
+
+version_file_with_extra_version_extra_dash = """
+VERSION_MAJOR = 1
+VERSION_MINOR = 2
+PATCHLEVEL = 3
+VERSION_TWEAK = 0
+EXTRAVERSION = rc1-12
+"""
+
+
+def test_creating_zephyrsemver_with_extra_field_with_extra_dash():
+    """Test creating ZephyrSemver when tag contains extra field with extra dash."""
+    zs = ZephyrSemver(ParsedTag.from_git_describe("v1.2.3-rc1-12-0-g98bddf3"))
+
+    assert zs.to_string() == "v1.2.3-rc1-12"
+    assert zs.to_version_file() == version_file_with_extra_version_extra_dash.strip()
+
+
+def test_giving_a_tag_without_leading_v():
+    """Test creating ZephyrSemver when the tag start with v."""
+    bad_tag = "1.2.3"
+
+    valid_extensions = ["-0-g98bddf3", "-0-g98bddf3+", "-4-g98bddf3", "-4-g98bddf3+"]
+
+    for valid_ext in valid_extensions:
+        with pytest.raises(ValueError, match=r".*Tag must start with 'v'.*"):
+            _ = ZephyrSemver(ParsedTag.from_git_describe(bad_tag + valid_ext))
+
+
+def test_giving_a_tag_with_non_numbers():
+    """Test creating ZephyrSemver when the tag doesn't contain numeric versions."""
+    bad_tags = ["va.2.3", "v1.a.3", "v1.2.a"]
+
+    valid_extensions = ["-0-g98bddf3", "-0-g98bddf3+", "-4-g98bddf3", "-4-g98bddf3+"]
+
+    for bad_tag in bad_tags:
+        for valid_ext in valid_extensions:
+            with pytest.raises(ValueError, match=r".*version must be an integer.*"):
+                _ = ZephyrSemver(ParsedTag.from_git_describe(bad_tag + valid_ext))
+
+
+def test_giving_a_tag_with_wrong_number_of_dots():
+    """Test creating ZephyrSemver when the tag doesn't follow MAJOR.MINOR.PATCH format."""
+    bad_tags = ["v1", "v1.2", "v1.2.3.4"]
+
+    valid_extensions = ["-0-g98bddf3", "-0-g98bddf3+", "-4-g98bddf3", "-4-g98bddf3+"]
+
+    for bad_tag in bad_tags:
+        for valid_ext in valid_extensions:
+            with pytest.raises(ValueError, match=r".*Expected format is.*"):
+                _ = ZephyrSemver(ParsedTag.from_git_describe(bad_tag + valid_ext))
+
+
+version_file_with_tweak_and_extra_version = """
+VERSION_MAJOR = 1
+VERSION_MINOR = 2
+PATCHLEVEL = 3
+VERSION_TWEAK = 4
+EXTRAVERSION = rc1
+"""
+
+version_file_with_tweak_and_extra_version_with_extra_dash = """
+VERSION_MAJOR = 1
+VERSION_MINOR = 2
+PATCHLEVEL = 3
+VERSION_TWEAK = 4
+EXTRAVERSION = rc1-12
+"""
+
+
+def test_tag_from_cmd():
+    """Test creating ZephyrSemver from command line."""
+
+    def helper(ver_str, version_file):
+        """Helper function for test creation ZephyrSemver from command line."""
+        zs = ZephyrSemver(ParsedTag.from_cmd(ver_str))
+        assert zs.to_string() == ver_str
+        assert zs.to_version_file() == version_file.strip()
+
+    helper("v0.0.0", version_file_no_tag)
+    helper("v1.2.3", version_file_on_tag)
+    helper("v1.2.3-rc1", version_file_with_extra_version)
+    helper("v1.2.3-rc1-12", version_file_with_extra_version_extra_dash)
+    helper("v1.2.3+4", version_file_not_on_tag_clean_or_dirty)
+    helper("v1.2.3-rc1+4", version_file_with_tweak_and_extra_version)
+    helper("v1.2.3-rc1-12+4", version_file_with_tweak_and_extra_version_with_extra_dash)


### PR DESCRIPTION
## Description

These classes will be used for the upcoming `east gen-version` and `east pack` commands.

Related: #125, #29


## Areas of interest for the reviewer

@TjazVracko please check only the doc strings (ZephyrSemverParsedTagApi and ParsedTag).
@TiborSovilj please check everything.

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed
      functions.
- [x] ~~I updated all customer-facing technical documentation.~~ - This PR introduced only internal facing changes. The external facing changes are pending.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
