### PR TITLE
feat: add TSuite class and it's tests

### DIFF
--- a/src/east/constants.py
+++ b/src/east/constants.py
@@ -4,6 +4,7 @@ import os
 # in __main__.
 # There are however exceptions: NRFUTIL_PATH, CPPCHECK_PATH,
 # CLANG_PATH, CODECHECKER_PATH are needed for downloading in install.py.
+# Also, EAST_GITHUB_URL can be accessed from other modules for documentation purposes.
 
 HOME_DIR = os.environ["HOME"]
 
@@ -47,6 +48,8 @@ MINICONDA_DIR = os.path.join(HOME_DIR, "miniconda3")
 
 # Path to the Conda executable, this can be used when the Conda is not yet on PATH.
 CONDA_PATH = os.path.join(MINICONDA_DIR, "bin", "conda")
+
+EAST_GITHUB_URL = "https://github.com/irnas/irnas-east-software"
 
 const_paths = {
     "cache_dir": CACHE_DIR,

--- a/src/east/modules/tsuite.py
+++ b/src/east/modules/tsuite.py
@@ -1,0 +1,74 @@
+import os
+from typing import NamedTuple, Sequence
+
+from ..constants import EAST_GITHUB_URL
+
+
+class TSuite(NamedTuple):
+    """TSuite object that represents a single testsuite in twister.json.
+
+    The class name was intentionally shortened to TSuite to avoid pytest's automatic
+    test discovery.
+    """
+
+    # Name of the testsuite, e.g., app.prod, samples.blinky
+    name: str
+    # Normalized board name, e.g., nrf52840dk_nrf52840 or nrf52840dk@1.0.0_nrf52840
+    board: str
+    # Raw board name from twister.json, e.g., nrf52840dk/nrf52840
+    raw_board: str
+    # Path to the project where the testsuite is located.
+    path: str
+    # Path to the testsuite's build directory inside the twister_out directory.
+    twister_out_path: str
+    # Status of the testsuite, e.g., passed, failed, skipped
+    status: str
+
+    @classmethod
+    def list_from_twister_json(cls, twister_json: dict) -> Sequence["TSuite"]:
+        """Create a list of TSuite objects from a list of testsuites from twister.json."""
+        if "testsuites" not in twister_json:
+            msg = (
+                f"<twister_out>/twister.json is missing the 'testsuites' key.\n\n"
+                "This shouldn't happen. Please report this "
+                f"to East's bug tracker on {EAST_GITHUB_URL}."
+            )
+            raise Exception(msg)
+
+        # WARN: All accessed fields should be checked for existence.
+        required_keys = set(["name", "platform", "run_id", "status"])
+
+        # Error due to missing required keys is not expected to happend often, so
+        # we error out immediately, if it happens.
+        # Error due to the failed runs is expected to happen more often, so we
+        # first process all testsuites, determine if there are any failed runs and
+        # then error out if needed.
+        def create_tsuite(d: dict):
+            """Create a single TSuite object from a dictionary."""
+            if not required_keys.issubset(d.keys()):
+                msg = (
+                    f"The following testsuite json: \n\n{d}\n\n in "
+                    f"<twister_out>/twister.json is missing one or more of the "
+                    "following keys: {required_keys}.\n\n"
+                    "This shouldn't happen. Please report this to East's bug tracker "
+                    f"on {EAST_GITHUB_URL}."
+                )
+                raise Exception(msg)
+
+            board = d["platform"].replace("/", "_")
+            name = os.path.basename(d["name"])
+
+            return cls(
+                name,
+                board=board,
+                raw_board=d["platform"],
+                path=os.path.dirname(d["name"]),
+                twister_out_path=os.path.join(board, d["name"]),
+                status=d["status"],
+            )
+
+        return [create_tsuite(ts) for ts in twister_json["testsuites"]]
+
+    def did_fail(self) -> bool:
+        """Check if the testsuite failed."""
+        return self.status != "passed"

--- a/tests/test_tsuite.py
+++ b/tests/test_tsuite.py
@@ -1,0 +1,81 @@
+import copy
+import os
+
+import pytest
+
+from east.modules.tsuite import TSuite
+
+test_suite_json = {
+    "testsuites": [
+        {
+            "name": "app/app.prod",
+            "arch": "arm",
+            "platform": "custom_board@1.0.0/nrf52840",
+            "path": "../project/app",
+            "run_id": "953b256c22f70c8293b9b625baea26ee",
+            "runnable": False,
+            "retries": 0,
+            "status": "passed",
+            "execution_time": "0.00",
+            "build_time": "26.15",
+            "testcases": [
+                {
+                    "identifier": "app.prod",
+                    "execution_time": "0.00",
+                    "status": "skipped",
+                    "reason": "Test was built only",
+                }
+            ],
+        }
+    ]
+}
+
+
+def test_creating_a_tsuite_instance():
+    """Test creating a list of TSuite instances.
+
+    GIVEN a testsuite JSON object,
+    WHEN creating a list of TSuite instances,
+    THEN the instance should have the correct attributes.
+    """
+    ts = TSuite.list_from_twister_json(test_suite_json)[0]
+
+    exp_twist_path = os.path.join(ts.board, test_suite_json["testsuites"][0]["name"])
+
+    assert ts.name == "app.prod"
+    assert ts.board == "custom_board@1.0.0_nrf52840"
+    assert ts.raw_board == "custom_board@1.0.0/nrf52840"
+    assert ts.path == "app"
+    assert ts.twister_out_path == exp_twist_path
+    assert ts.status == "passed"
+
+
+def test_checking_for_a_not_ok_testsuite_status():
+    """Test checking for a not OK testsuite status.
+
+    GIVEN a testsuite JSON object with status different from "passed",
+    WHEN creating a TSuite instance,
+    THEN list of bad testsuites should contain an entry
+    """
+    bad_test_suite_json = copy.deepcopy(test_suite_json)
+    bad_test_suite_json["testsuites"][0]["status"] = "failed"
+
+    testsuites = TSuite.list_from_twister_json(bad_test_suite_json)
+
+    assert any([ts.did_fail() for ts in testsuites])
+
+
+def test_raising_exception_for_a_bad_testsuite_json():
+    """Test checking for a bad testsuite json.
+
+    testsuite json is considered bad if doesn't contain all keys expected by the TSuite
+    class.
+
+    GIVEN a testsuite JSON object with missing keys
+    WHEN creating a TSuite instance,
+    THEN the exception should be raised.
+    """
+    test_suite_json_bad = {"testsuites": [{"name": "app/app.prod"}]}
+
+    with pytest.raises(Exception):
+        _ = TSuite.list_from_twister_json(test_suite_json_bad)


### PR DESCRIPTION
## Description

Added a new `TSuite` class to represent a single testsuite in twister.json. This class provides functionality to parse testsuite data from twister.json files and check for test failures. Also added a constant `EAST_GITHUB_URL` for documentation purposes.

## Areas of interest for the reviewer

- The `TSuite` class implementation in `src/east/modules/tsuite.py`
- Test cases in `tests/test_tsuite.py`
- Error handling for missing keys in twister.json

## Checklist

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
 - This PR only adds internal functionality.

## After-review steps

- Code author will merge this PR

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md