### PR TITLE
feat: add ArtifactsToPack class and it's tests

### DIFF
--- a/src/east/modules/artifacts2pack.py
+++ b/src/east/modules/artifacts2pack.py
@@ -1,0 +1,48 @@
+from typing import Any, NamedTuple
+
+from ..constants import EAST_GITHUB_URL
+
+
+class ArtifactsToPack(NamedTuple):
+    """ArtifactsToPack object represents the artifacts to be packed, specific to a
+    project.
+    """
+
+    common_artifacts: list[str]
+    proj_artifacts: dict[str, list[str]]
+
+    @classmethod
+    def from_east_yml(cls, east_yml: dict[str, Any]):
+        """Create an ArtifactsToPack object from the 'pack' field of east.yml."""
+        if "pack" not in east_yml:
+            raise Exception(
+                "The [bold magenta]pack[/] field is missing from the "
+                "[bold yellow]east.yml[/] file. Add it and try again."
+            )
+
+        pack = east_yml["pack"]
+        common_artifacts = pack.get("artifacts", [])
+        projects = pack.get("projects", [])
+
+        proj_artifacts = {}
+
+        for p in projects:
+            if "artifacts" in p:
+                proj_artifacts[p["name"]] = common_artifacts + p["artifacts"]
+            elif "overwrite_artifacts" in p:
+                proj_artifacts[p["name"]] = p["overwrite_artifacts"]
+            else:
+                raise Exception(
+                    "One of 'artifact' or 'overwrite_artifact' keys must be present in "
+                    "the project.\n\nThis shouldn't happen. Please report this "
+                    f"to East's bug tracker on {EAST_GITHUB_URL}."
+                )
+
+        return cls(common_artifacts, proj_artifacts)
+
+    def get_artifacts_for_project(self, project: str) -> list[str]:
+        """Return a list of artifacts for a given project.
+
+        If that project is not found, return the common artifacts.
+        """
+        return self.proj_artifacts.get(project, self.common_artifacts)

--- a/tests/test_artifact2pack.py
+++ b/tests/test_artifact2pack.py
@@ -1,0 +1,38 @@
+import yaml
+
+from east.modules.artifacts2pack import ArtifactsToPack
+
+pack_yaml_single_app = """
+pack:
+  artifacts:
+    - $APP_DIR/zephyr/merged.hex
+  projects:
+    - name: app.prod
+      artifacts:
+        - $APP_DIR/zephyr/zephyr.hex
+        - dfu_application.zip
+"""
+
+
+def test_getting_artifact_list_for_listed_project():
+    """Test getting a list of artifacts for the that is listed in the east.yml."""
+    atp = ArtifactsToPack.from_east_yml(yaml.safe_load(pack_yaml_single_app))
+
+    arts = atp.get_artifacts_for_project("app.prod")
+
+    assert arts == [
+        "$APP_DIR/zephyr/merged.hex",
+        "$APP_DIR/zephyr/zephyr.hex",
+        "dfu_application.zip",
+    ]
+
+
+def test_getting_artifact_list_for_unlisted_project():
+    """Test getting a list of artifacts for the project that isn't listed in the east.yml."""
+    atp = ArtifactsToPack.from_east_yml(yaml.safe_load(pack_yaml_single_app))
+
+    arts = atp.get_artifacts_for_project("app.krneki")
+
+    assert arts == [
+        "$APP_DIR/zephyr/merged.hex",
+    ]


### PR DESCRIPTION
## Description

Added a new module `artifacts2pack.py` that provides functionality to handle artifacts for packing in East projects. The module introduces an `ArtifactsToPack` class that parses the `pack` field from the `east.yml` configuration file and manages both common artifacts and project-specific artifacts.

Also added tests to verify the functionality of retrieving artifact lists for both listed and unlisted projects.

## Areas of interest for the reviewer

- The error handling in the `from_east_yml` method
- The logic for combining common artifacts with project-specific ones

## Checklist

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- This PR only adds internal functionality.

## After-review steps

- Code author will merge the PR.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md