### PR TITLE
misc: Deprecate east release

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,6 @@
 rich == 13.7.1
-click == 8.1.7
-rich_click == 1.8.3
+click == 8.2.1
+rich_click == 1.8.9
 requests == 2.32.3
 PyYAML >= 6.0.0
 pykwalify == 1.8.0

--- a/src/east/workspace_commands/release_commands.py
+++ b/src/east/workspace_commands/release_commands.py
@@ -387,7 +387,7 @@ def non_existing_sample_msg_fmt(sample_name):
     )
 
 
-@click.command(**east_command_settings)
+@click.command(**east_command_settings, deprecated="Replaced by `east pack`")
 @click.option(
     "-d",
     "--dry-run",


### PR DESCRIPTION
## Description

Add a deprecation warning to `east release`.

I updated `click` so that I could add a custom string to the deprecation warning - they added that in 8.2.

How this looks:
`east --help`
![image](https://github.com/user-attachments/assets/178169d7-e2a8-4f4e-acc3-351f91a6ce3e)
 
![image](https://github.com/user-attachments/assets/13d83cea-341f-4c72-a2a1-afe0dd3946e5)


## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed
      functions.
- [x] ~~I updated all customer-facing technical documentation.~~ - Docs will be updated
      in a separate PR.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
