### PR TITLE
fix(CI): Fix PR labeler sometimes failing

### DIFF
--- a/.github/label_pr.yml
+++ b/.github/label_pr.yml
@@ -2,17 +2,17 @@ name: Label PR
 on:
   pull_request:
     types: [opened]
-
 permissions:
   contents: read
-
 jobs:
   pr-labeler:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-22.04
+      issues: write
+    runs-on: ubuntu-latest
     steps:
-      - uses: TimonVS/pr-labeler-action@v4.1.1
+      - uses: TimonVS/pr-labeler-action@v5.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/pr-labeler.yaml


### PR DESCRIPTION
Prevent PR labeler action from failing sometimes, by also giving it the `issues:write` permission.

See [PR labeler repo](https://github.com/actions/labeler/issues/870) issue for details.

Also update the version of the action.