### PR TITLE
misc: Deprecate --build-type in east build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Deprecate `east release`. A warning is printed when the command is used. The command will be
   removed in some future release. Use `east pack` instead.
+- Deprecate the `--build-type` option in the `east build` command. A warning is printed when the
+  option is used. The option will be removed in some future release. Use `sample.yaml` files instead
+  and build with `east build -b <board> . -T <build_config>`.
 
 ### Removed
 

--- a/src/east/workspace_commands/basic_commands.py
+++ b/src/east/workspace_commands/basic_commands.py
@@ -52,6 +52,7 @@ class SpecialCommand(RichCommand):
         " [bold yellow]east.yml[/] with possible build types with specified apps and "
         "samples."
     ),
+    deprecated="Use [bold]sample.yml[/] files instead.",
 )
 @click.option(
     "--spdx",
@@ -82,9 +83,6 @@ def build(ctx, east, build_type, spdx, extra_help, args):
     \n\nTo pass additional arguments to the [bold]CMake[/] invocation performed by the [magenta
     bold]west build[/], pass them after a [bold white]"--"[/] at the end of the command line.
 
-    \n\nIf the source dir is listed in the [bold yellow]east.yml[/] then [bold yellow]build type[/] functionality is enabled. East will add a group of [bold]Kconfig[/] fragment files to the build as specified by the selected build type and [bold yellow]east.yml[/] file. See [bold]docs/configuration.md[/] for more info.
-
-    \n\n[bold]Note:[/] When using build types functionality make sure to not pass CONF_FILE and OVERLAY_CONFIG variables to the [bold]CMake[/].
     \n\n[bold]Note:[/] This command can be only run from inside of a [bold yellow]West workspace[/].
     """
     _ = args


### PR DESCRIPTION
# Description

Deprecate `--build-type` in `east build`

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and
write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] I updated all customer-facing technical documentation.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
