### PR TITLE
fix: Fix quote escaping in helper_functions.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   option is used. The option will be removed in some future release. Use `sample.yaml` files instead
   and build with `east build -b <board> . -T <build_config>`.
 
+### Fixed
+
+- Fixed `east build` esaping to many quotes when providing extra config values that are strings.
+  Command such as `east build -b <board> ---DCONFIG_SOMETHING=\"string\"` now work as expected.
+
 ### Removed
 
 - Removed support for Python v3.9 and below.

--- a/src/east/helper_functions.py
+++ b/src/east/helper_functions.py
@@ -334,9 +334,14 @@ def clean_up_extra_args(args):
 
     def add_back_double_quotes(arg):
         if arg.startswith("-") and "=" in arg:
-            # Split by the first "=" and add double quotes to the value
+            # Split by the first "="
             split = arg.split("=", 1)
-            arg = f'{split[0]}="{split[1]}"'
+            # If the value is already quoted, add a backspace to escape the quote.
+            # If not quoted, do nothing.
+            if split[1].startswith('"') and split[1].endswith('"'):
+                split[1] = split[1].replace('"', '\\"')
+            # Rejoin the split parts with an equal sign
+            arg = f"{split[0]}={split[1]}"
         else:
             # The arg is not an option of any kind, just add double quotes if it
             # contains a space

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,24 @@
+from east.helper_functions import clean_up_extra_args
+
+
+def test_clean_up_extra_args():
+    """Test that arguments are correctly cleaned up and concatenated.
+
+    If arg is "-DXXX=yyy:
+        If yyy has quotes, they must be escaped.
+        If yyy has no quotes, do nothing.
+    If arg is something else, add quotes around it if it contains spaces.
+    """
+    args = [
+        "-DCONFIG_1=1000",
+        "-DCONFIG_2=y",
+        '-DCONFIG_3="quoted string"',
+        '"quotes"',
+        "arg with spaces",
+    ]
+
+    expected = '-DCONFIG_1=1000 -DCONFIG_2=y -DCONFIG_3=\\"quoted string\\" "quotes" "arg with spaces"'
+
+    cleaned_args = clean_up_extra_args(args)
+
+    assert cleaned_args == expected


### PR DESCRIPTION
# Description

When a string config value was provided, the quote escaping was not
handled correctly. Now, we correctly pass the escaped quotes to
west build.

Closes #132

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and
write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] ~~I updated all customer-facing technical documentation.~~ - This PR
      introduced only internal facing changes.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
