### PR TITLE
fix: Deprecation warning for --build-type not printing correctly

### DIFF
--- a/src/east/workspace_commands/basic_commands.py
+++ b/src/east/workspace_commands/basic_commands.py
@@ -52,7 +52,7 @@ class SpecialCommand(RichCommand):
         " [bold yellow]east.yml[/] with possible build types with specified apps and "
         "samples."
     ),
-    deprecated="Use [bold]sample.yml[/] files instead.",
+    deprecated="Use sample.yml files instead.",
 )
 @click.option(
     "--spdx",


### PR DESCRIPTION
# Description

For some reason, the rich formatting is not being applied.
We don't want this:
![image](https://github.com/user-attachments/assets/2468e588-eecf-4051-8f7a-d51185fb5e4e)


## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and
write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] ~~I updated all customer-facing technical documentation.~~ - This PR
      introduced only internal facing changes.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
