### PR TITLE
fix: Ignore filtered testsuites when parsing twsiter.json

### DIFF
--- a/src/east/modules/tsuite.py
+++ b/src/east/modules/tsuite.py
@@ -95,7 +95,11 @@ class TSuite(NamedTuple):
                 toolchain=toolchain,
             )
 
-        return [create_tsuite(ts) for ts in twister_json["testsuites"]]
+        return [
+            create_tsuite(ts)
+            for ts in twister_json["testsuites"]
+            if ts.get("status", "") != "filtered"
+        ]
 
     def did_fail(self) -> bool:
         """Check if the testsuite failed."""

--- a/tests/test_tsuite.py
+++ b/tests/test_tsuite.py
@@ -71,6 +71,32 @@ test_suite_json = {
                 }
             ],
         },
+        # This is a testsuite that was filtered out
+        # This happens on older NCSs. On new ones, filtered testsuites are
+        # not in twister.json at all.
+        #
+        # After parsing, it should not appear in any TSuite list
+        {
+            "name": "app/app.filtered",
+            "arch": "arm",
+            "platform": "custom_board@1.0.0/nrf52840",
+            "path": "../project/app",
+            "run_id": "953b256c22f70c8293b9b625baea26ef",
+            "runnable": False,
+            "retries": 0,
+            "status": "filtered",
+            "execution_time": "0.00",
+            "build_time": "26.15",
+            "toolchain": "host",
+            "testcases": [
+                {
+                    "identifier": "app.filtered",
+                    "execution_time": "0.00",
+                    "status": "filtered",
+                    "reason": "Not in testsuite platform allow list",
+                }
+            ],
+        },
     ],
 }
 
@@ -83,6 +109,10 @@ def test_creating_tsuite_instances():
     THEN the instance should have the correct attributes.
     """
     ts = TSuite.list_from_twister_json(test_suite_json)
+
+    # With this assertion we ensure that the testsuite JSON
+    # contains the expected number of testsuites.
+    # The fourth testsuite is filtered out, so it should not be in the list.
     assert len(ts) == 3
 
     v3 = ts[0]


### PR DESCRIPTION
# Description

fix: Ignore filtered testsuites when parsing twsiter.json

On OLD NCS versions, the `twister.json` file would contain
testsuites that were filtered out by the `twister` tool.
They have status: "filtered".

We now skip all of those testsuites when parsing the
`twister.json` file, since they do not have any build directories
and are not relevant for the user of east pack.

Closes #152

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and
write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] ~~I updated all customer-facing technical documentation.~~ - This PR
      introduced only internal facing changes.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
