### PR TITLE
fix: Clamp version numbers in the `east util version` command to 255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Limit major, minor, patch numbers in the `east util version` command to 255, error out if they are
+  exceeded. This is done to ensure compatibility with the Zephyr's VERSION file, which only
+  allocates 1 byte for each version number. It is important to respect this due to the MCUboot.
+  Limit the tweak number also to 255, but don't error out in that case, just set it to 0. It is a
+  valid used case to be more than 255 commits away from the last tagged commit. We can clamp the
+  tweak number as it is always 0 in the cases of the release, so the above MCUboot consideration
+  doesn't apply to it.
+
 ## [0.29.2] - 2025-06-30
 
 ### Fixed

--- a/src/east/modules/zephyr_semver.py
+++ b/src/east/modules/zephyr_semver.py
@@ -50,6 +50,36 @@ def _parse_tag(tag: str) -> Tuple[int, int, int, str, int]:
     minor = _parse_int_version(parts[1], tag, "Minor")
     patch = _parse_int_version(parts[2], tag, "Patch")
 
+    def check_255_limit(ver, name):
+        """Check if the version part is within the 255 limit.
+
+        This is needed as the Zephyr' VERSION file only alloacates 1 byte for each
+        field.
+        """
+        if ver > 255:
+            raise Exception(
+                f"{name} (ver) exceeded limit of 1 byte (255). Zephyr's "
+                "VERSION file only allows 1 byte for each field."
+            )
+        return ver
+
+    def clamp_tweak(tweak):
+        """Clamp tweak number to 255, if above that.
+
+        Zephyr's VERSION file only alloacates 1 byte for the tweak field. However, in
+        the case of the tweak we clamp it to 255, instead of erroring, since being 255
+        commits from the tag is a valid use case.
+        """
+        if tweak > 255:
+            print(f"Warning: Tweak number ({tweak}) exceeds 255, clamping it to 255.")
+            return 255
+        return tweak
+
+    major = check_255_limit(major, "major")
+    minor = check_255_limit(minor, "minor")
+    patch = check_255_limit(patch, "patch")
+    tweak = clamp_tweak(tweak)
+
     return major, minor, patch, extra, tweak
 
 


### PR DESCRIPTION
Zephyr's VERSION file only allocates 1 byte for each version number.

It is a realistic usecase that someone will be more than 255 commits away from the last tagged commit. In that case the East will generate a invalid VERSION file.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
